### PR TITLE
dockerize bigq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Pull base image.
+FROM node:4.2.3
+
+# Set app path directory to WORKDIR and run install
+WORKDIR /code
+COPY ./node_modules/jsdog-meli /code/node_modules/jsdog-meli
+
+COPY package.json /code/
+COPY npm-shrinkwrap.json /code/
+COPY Makefile /code/
+
+RUN npm install
+
+# Add source code to container (all but in dockeringnore)
+COPY . /code
+
+# Exporse default port
+EXPOSE 8081
+
+# run 
+CMD ["./bin/http_launcher.js"]
+

--- a/bin/os_http_admin_launcher.js
+++ b/bin/os_http_admin_launcher.js
@@ -37,9 +37,14 @@ var httpConfig = {
 
 //Check for external config
 var config
-console.log(externalConfig)
-console.log("Loading ["+externalConfig+"]");
-config = require(externalConfig).httpApiConfig;
+if (externalConfig) {
+  console.log(externalConfig)
+  console.log("Loading ["+externalConfig+"]");
+  config = require(externalConfig).httpApiConfig;
+} else {
+  config = httpConfig
+}
+
 log.setLevel(config.logLevel || "error");
 
 //Run config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+bigqueue:
+  build: .
+  ports:
+   - "8081:8081"
+  net: "host"
+  volumes:
+   - .:/app
+ 
+redis:
+  image: redis
+  ports:
+   - "127.0.0.1:6379:6379"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "name": "bigqueue",
+  "dependencies": {
+    "qs": {
+      "version": "5.2.0",
+      "from": "qs@v5.2.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "description": "",
   "version": "0.2.0",
   "author": "",
-  "engines": {
-    "node": ">= 0.8.21"
-  },
   "bin": {
     "bigqueue-http": "./bin/http_launcher.js",
     "os-http-admin-api": "./bin/os_http_admin_launcher.js",
@@ -21,7 +18,7 @@
     "async": "0.7.0",
     "body-parser": "1.3.0",
     "express": "4.4.1",
-    "hiredis": "0.1.16",
+    "hiredis": "*",
     "json2yaml": "1.0.x",
     "method-override": "2.1.1",
     "morgan": "1.1.1",
@@ -32,11 +29,25 @@
     "request": "2.9.x",
     "should": "0.6.x",
     "winston": "0.7.3",
-    "jsdog": "git+ssh://git@github.com:mercadolibre/jsdog.git",
     "shuffle-array":"0.0.2"
   },
   "devDependencies": {
     "mocha": "1.8.x",
-    "nock": "0.31.1"
+    "nock": "0.31.1",
+    "async": "0.7.0",
+    "body-parser": "1.3.0",
+    "express": "4.4.1",
+    "hiredis": "*",
+    "json2yaml": "1.0.x",
+    "method-override": "2.1.1",
+    "morgan": "1.1.1",
+    "mysql": "2.0.1",
+    "needle": "0.7.1",
+    "node-cache": "1.0.0",
+    "redis": "0.10.1",
+    "request": "2.9.x",
+    "should": "0.6.x",
+    "winston": "0.7.3",
+    "shuffle-array":"0.0.2"
   }
 }


### PR DESCRIPTION
* Dockerfile
  * jsdog-meli not open source  -> so copy local modules on build (fixme)
* os_http_admin_launcher.js -> default config
* Docker Compose net "host" (fixme: change for links)
* package.json node 4 and some modules versions change
* npm-shrinkwrap.json for deep dependencies needle module